### PR TITLE
Fix a bug where a user could leave a buffer with unsaved changes

### DIFF
--- a/pyvim/commands/commands.py
+++ b/pyvim/commands/commands.py
@@ -197,14 +197,26 @@ def _(editor):
 
 @_cmd('b')
 @_cmd('buffer')
-def _(editor, variables):
+def _buffer(editor, variables, force=False):
     """
     Go to one of the open buffers.
     """
+    eb = editor.window_arrangement.active_editor_buffer
+
     buffer_name = variables.get('buffer_name')
     if buffer_name:
-        editor.window_arrangement.go_to_buffer(buffer_name)
+        if not force and eb.has_unsaved_changes:
+            editor.show_message('No write since last change (add ! to override)')
+        else:
+            editor.window_arrangement.go_to_buffer(buffer_name)
 
+@_cmd('b!')
+@_cmd('buffer!')
+def _(editor, variables):
+    """
+    Force go to one of the open buffers.
+    """
+    _buffer(editor, variables, force=True)
 
 @cmd('bw')
 def _(editor):


### PR DESCRIPTION
 Fix a bug where a user could leave a buffer with unsaved changes by issuing a :b [arg] or :buffer [arg] editor command

Repro:
Open pyvim file1 file2
Edit file 1 without issuing a write command
Attempt to switch to file2's buffer (':b file2' or ':b 1')
Without the fix this will succeed

After the fix this displays an editor message ('No write since last change (add ! to override)') similar to the official vim.
