### PR TITLE
fix ctrl-f shortcut

### DIFF
--- a/pyvim/key_bindings.py
+++ b/pyvim/key_bindings.py
@@ -47,7 +47,7 @@ def create_key_bindings(editor):
         if w and w.render_info:
             new_document_line = min(
                 b.document.line_count - 1,
-                b.document.cursor_position_row + int(w.render_info.rendered_height / 2))
+                b.document.cursor_position_row + int(w.render_info.rendered_height))
             b.cursor_position = b.document.translate_row_col_to_index(new_document_line, 0)
             w.vertical_scroll = w.render_info.input_line_to_screen_line(new_document_line)
 


### PR DESCRIPTION
This fixes the `Ctrl-F` shortcut to scroll one page down, instead of half.