### PR TITLE
Pytest, fixed tests, added tox, added mistune to dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,6 +145,29 @@ Maybe we will also have line folding and probably block editing. Maybe some
 day we will have a built-in Python debugger or mouse support. We'll see. :)
 
 
+Testing
+-------
+
+To run all tests, install pytest:
+
+    pip install pytest
+
+And then run from root pyvim directory:
+
+    py.test
+
+To test pyvim against all supported python versions, install tox:
+
+    pip install tox
+
+And then run from root pyvim directory:
+
+    tox
+
+You need to have installed all the supported versions of python in order to run
+tox command successfully (2.6, 2.7, 3.1, 3.2, 3.3, 3.4).
+
+
 Why did I create Pyvim?
 -----------------------
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+from __future__ import unicode_literals
+
+import pytest
+
+from prompt_toolkit.buffer import Buffer
+from pyvim.window_arrangement import TabPage, EditorBuffer, Window
+
+
+@pytest.fixture
+def prompt_buffer():
+    return Buffer()
+
+
+@pytest.fixture
+def editor_buffer(prompt_buffer):
+    return EditorBuffer(prompt_buffer, 'b1')
+
+
+@pytest.fixture
+def window(editor_buffer):
+    return Window(editor_buffer)
+
+
+@pytest.fixture
+def tab_page(window):
+    return TabPage(window)

--- a/tests/test_window_arrangements.py
+++ b/tests/test_window_arrangements.py
@@ -1,33 +1,21 @@
 from __future__ import unicode_literals
 
 from prompt_toolkit.buffer import Buffer
-from pyvim.window_arrangement import TabPage, EditorBuffer, Window, HSplit, VSplit
-
-import unittest
+from pyvim.window_arrangement import EditorBuffer, VSplit
 
 
-class BufferTest(unittest.TestCase):
-    def setUp(self):
-        b = Buffer()
-        eb = EditorBuffer('b1', b)
-        self.window = Window(eb)
-        self.tabpage = TabPage(self.window)
-
-    def test_initial(self):
-        self.assertIsInstance(self.tabpage.root, VSplit)
-        self.assertEqual(self.tabpage.root, [self.window])
-
-    def test_vsplit(self):
-        # Create new buffer.
-        b = Buffer()
-        eb = EditorBuffer('b1', b)
-
-        # Insert in tab, by splitting.
-        self.tabpage.vsplit(eb)
-
-        self.assertIsInstance(self.tabpage.root, VSplit)
-        self.assertEqual(len(self.tabpage.root), 2)
+def test_initial(window, tab_page):
+    assert isinstance(tab_page.root, VSplit)
+    assert tab_page.root == [window]
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_vsplit(tab_page):
+    # Create new buffer.
+    b = Buffer()
+    eb = EditorBuffer(b, 'b1')
+
+    # Insert in tab, by splitting.
+    tab_page.vsplit(eb)
+
+    assert isinstance(tab_page.root, VSplit)
+    assert len(tab_page.root) == 2

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 envlist = py26,py27,py31,py32,py33,py34
 
 [testenv]
-deps=mistune
-     pytest
+deps=pytest
      prompt-toolkit==0.34
      ptpython==0.8
      pyflakes

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py26,py27,py31,py32,py33,py34
+
+[testenv]
+deps=mistune
+     pytest
+     prompt-toolkit==0.34
+     ptpython==0.8
+     pyflakes


### PR DESCRIPTION
I rewrote the test from unittest to pytest and fixed broken tests. Also I added mistune to setup.py, added tox.ini for python's tox package for multiple python versions testing.

However, I suggest dropping support for Python 2.6 and 3.1 these are broken under tox.
Python2.6 has somehow broken virtualenv
Python3.1 has broken urllib .. 
Maybe these can be fixed, but I think almost nobody uses these versions of python.