### PR TITLE
Implement file explorer

### DIFF
--- a/pyvim/commands/commands.py
+++ b/pyvim/commands/commands.py
@@ -273,6 +273,7 @@ def buffer_edit(editor, location, force=False):
         else:
             eb.reload()
     else:
+        editor.file_explorer = ''
         editor.window_arrangement.open_buffer(location, show_in_current_window=True)
 
 

--- a/pyvim/editor.py
+++ b/pyvim/editor.py
@@ -64,6 +64,8 @@ class Editor(object):
         self.cursorline = False  # ':set cursorline'
         self.cursorcolumn = False  # ':set cursorcolumn'
         self.colorcolumn = []  # ':set colorcolumn'. List of integers.
+        self.file_explorer = ''  # Empty if not in file explorer mode,
+                                 # directory path otherwise.
 
         # Ensure config directory exists.
         self.config_directory = os.path.abspath(os.path.expanduser(config_directory))

--- a/pyvim/editor_buffer.py
+++ b/pyvim/editor_buffer.py
@@ -36,6 +36,9 @@ class EditorBuffer(object):
         #: is_new: True when this file does not yet exist in the storage.
         self.is_new = True
 
+        # Empty if not in file explorer mode, directory path otherwise.
+        self.file_explorer = ''
+
         # Read text.
         if location:
             text = self._read(location)
@@ -74,6 +77,17 @@ class EditorBuffer(object):
             if io.can_open_location(location):
                 # Found an I/O backend.
                 exists = io.exists(location)
+                if io.isdir(location):
+                    # Location is a directory, get the path from the editor
+                    # if already in file explorer mode, otherwise set the
+                    # file explorer mode and send the path to the editor.
+                    if self.editor.file_explorer:
+                        self.file_explorer = self.editor.file_explorer
+                    else:
+                        self.file_explorer = location
+                        self.editor.file_explorer = location
+                else:
+                    self.editor.file_explorer = ''
                 if exists in (True, NotImplemented):
                     # File could exist. Read it.
                     self.is_new = False

--- a/pyvim/io/backends.py
+++ b/pyvim/io/backends.py
@@ -116,6 +116,8 @@ class DirectoryIO(EditorIO):
         result.append('" Directory Listing\n')
         result.append('"    %s\n' % os.path.abspath(directory))
         result.append('" ==================================\n')
+        result.append('../\n')
+        result.append('./\n')
 
         for d in directories:
             result.append('%s/\n' % d)
@@ -127,6 +129,9 @@ class DirectoryIO(EditorIO):
 
     def write(self, location, text, encoding):
         raise NotImplementedError('Cannot write to directory.')
+
+    def isdir(self, location):
+        return True
 
 
 class HttpIO(EditorIO):

--- a/pyvim/io/base.py
+++ b/pyvim/io/base.py
@@ -44,3 +44,9 @@ class EditorIO(six.with_metaclass(ABCMeta, object)):
         Write file to storage.
         Can raise IOError.
         """
+
+    def isdir(self, location):
+        """
+        Return whether this location is a directory.
+        """
+        return False

--- a/pyvim/window_arrangement.py
+++ b/pyvim/window_arrangement.py
@@ -431,6 +431,7 @@ class WindowArrangement(object):
                 return eb
             else:
                 # Found! Return it.
+                self.editor.file_explorer = eb.file_explorer
                 return eb
 
     def open_buffer(self, location=None, show_in_current_window=False):

--- a/pyvim/window_arrangement.py
+++ b/pyvim/window_arrangement.py
@@ -306,6 +306,7 @@ class WindowArrangement(object):
         """
         Show this EditorBuffer in the current window.
         """
+        self.editor.file_explorer = editor_buffer.file_explorer
         self.active_tab.show_editor_buffer(editor_buffer)
 
         # Clean up buffers.
@@ -426,6 +427,11 @@ class WindowArrangement(object):
             if eb is None:
                 # Create and add EditorBuffer
                 eb = EditorBuffer(self.editor, new_name(), location)
+                if eb.file_explorer:
+                    # Set cursor to beginning of file list
+                    eb.buffer.cursor_position = 0
+                    for _ in range(4):
+                        eb.buffer.cursor_position += eb.buffer.document.get_end_of_line_position() + 1
                 self._add_editor_buffer(eb)
 
                 return eb


### PR DESCRIPTION
When opening a directory, the file or directory under the cursor can be opened by pressing Enter.
I used a `file_explorer` attribute for each `editor_buffer`, and for the `editor`, which is synced with the current buffer. When the `file_explorer` attribute is not empty, it means that we are in "file explorer mode" and its content is the path of the directory we are in.